### PR TITLE
Added scripts for electrons

### DIFF
--- a/test/apply_bdt_tmva_electrons.py
+++ b/test/apply_bdt_tmva_electrons.py
@@ -21,10 +21,10 @@ from sklearn.metrics import classification_report, roc_auc_score, roc_curve
 from sklearn import tree
 import cPickle
 
-histo_sk_sig=TH1F('histo_sk_sig', 'scikit-learn BDT score for signal', 200, -1.0, 1.0)
-histo_sk_bkg=TH1F('histo_sk_bkg', 'scikit-learn BDT score for background', 200, -1, 1)
-histo_tmva_sig=TH1F('histo_tmva_sig', 'TMVA/TskMVA BDT score for signal', 200, -1, 1)
-histo_tmva_bkg=TH1F('histo_tmva_bkg', 'TMVA/TskMVA BDT score for background', 200, -1, 1)
+histo_sk_sig=TH1F('histo_sk_sig', 'Electrons: scikit-learn BDT score for signal', 200, -1.0, 1.0)
+histo_sk_bkg=TH1F('histo_sk_bkg', 'Electrons: scikit-learn BDT score for background', 200, -1, 1)
+histo_tmva_sig=TH1F('histo_tmva_sig', 'Electrons: TMVA/TskMVA BDT score for signal', 200, -1, 1)
+histo_tmva_bkg=TH1F('histo_tmva_bkg', 'Electrons: TMVA/TskMVA BDT score for background', 200, -1, 1)
 
 reader = ROOT.TMVA.Reader()
 
@@ -43,7 +43,8 @@ reader.AddVariable("m_el_ptcone20Dpt", m_el_ptcone20Dpt)
 
 # Download BDT weights
 #reader.BookMVA("BDT","MVAnalysis_BDT.weights.xml")
-reader.BookMVA("BDT","SKLearn_BDT_electons.weights.xml")
+reader.BookMVA("BDT",
+    "/Users/musthero/Documents/Yura/Applications/koza4ok/test/ttH_Run1_LeptonID/weights/SKLearn_BDT_electons.weights.xml")
 
 # Read ROOT file with the events to classify
 input_filename = "/Users/musthero/Documents/Yura/Applications/TMVA-v4.2.0/test/output_electrons_fullsim_v5_20per.root"
@@ -52,7 +53,7 @@ if file.IsZombie():
     print "Root file is corrupt"
 
 # sklearn
-fid = open('electrons_v5_VeryTightLH_20per.pkl', 'rb') 
+fid = open('/Users/musthero/Documents/Yura/Applications/tmva_local/electrons_v5_VeryTightLH_20per.pkl', 'rb') 
 bdt = cPickle.load(fid)
 
 # Get a handle to the tree
@@ -65,7 +66,7 @@ for event in t:
         print "Event number %i" % c
         sys.stdout.flush()
 
-    if c == 100000: break
+    #if c == 100000: break
 
     if not event.m_el_VeryTightLH == 1 : continue
 
@@ -82,17 +83,17 @@ for event in t:
     #score = bdt.predict([m_el_pt[0], m_el_eta[0], m_el_sigd0PV[0], m_el_z0SinTheta[0], 
     #    m_el_etcone20Dpt[0], m_el_ptcone20Dpt[0]]).item(0)
 
-    score = bdt.decision_function([m_el_pt[0], m_el_eta[0], m_el_sigd0PV[0], m_el_z0SinTheta[0], 
-        m_el_etcone20Dpt[0], m_el_ptcone20Dpt[0]]).item(0)
+    #score = bdt.decision_function([m_el_pt[0], m_el_eta[0], m_el_sigd0PV[0], m_el_z0SinTheta[0], 
+    #    m_el_etcone20Dpt[0], m_el_ptcone20Dpt[0]]).item(0)
 
     # calculate the value of the classifier with TMVA/TskMVA
     bdtOutput = reader.EvaluateMVA("BDT")
 
     if m_el_isprompt == 0:
-        histo_sk_bkg.Fill(score)
+        #histo_sk_bkg.Fill(score)
         histo_tmva_bkg.Fill(bdtOutput)
     elif m_el_isprompt == 1:
-        histo_sk_sig.Fill(score)
+        #histo_sk_sig.Fill(score)
         histo_tmva_sig.Fill(bdtOutput)
     else:
         print "Warning: m_mu_isprompt is not 0 or 1!!!"
@@ -101,7 +102,7 @@ file.Close()
 
 
 # Save histograms to file
-output_filename = "BDT_score_distributions_electrons.root"
+output_filename = "/Users/musthero/Documents/Yura/Applications/tmva_local/BDT_score_distributions_electrons.root"
 output_file = ROOT.TFile(output_filename,"RECREATE")
 histo_sk_sig.Write()
 histo_sk_bkg.Write()

--- a/test/apply_bdt_tmva_muons.py
+++ b/test/apply_bdt_tmva_muons.py
@@ -21,10 +21,10 @@ from sklearn.metrics import classification_report, roc_auc_score, roc_curve
 from sklearn import tree
 import cPickle
 
-histo_sk_sig=TH1F('histo_sk_sig', 'scikit-learn BDT score for signal', 200, -1.0, 1.0)
-histo_sk_bkg=TH1F('histo_sk_bkg', 'scikit-learn BDT score for background', 200, -1, 1)
-histo_tmva_sig=TH1F('histo_tmva_sig', 'TMVA/TskMVA BDT score for signal', 200, -1, 1)
-histo_tmva_bkg=TH1F('histo_tmva_bkg', 'TMVA/TskMVA BDT score for background', 200, -1, 1)
+histo_sk_sig=TH1F('histo_sk_sig', 'Muons: scikit-learn BDT score for signal', 200, -1.0, 1.0)
+histo_sk_bkg=TH1F('histo_sk_bkg', 'Muons: scikit-learn BDT score for background', 200, -1, 1)
+histo_tmva_sig=TH1F('histo_tmva_sig', 'Muons: TMVA/TskMVA BDT score for signal', 200, -1, 1)
+histo_tmva_bkg=TH1F('histo_tmva_bkg', 'Muons: TMVA/TskMVA BDT score for background', 200, -1, 1)
 
 reader = ROOT.TMVA.Reader()
 

--- a/test/draw_roc_vs_stat_rect_cuts_electrons.py
+++ b/test/draw_roc_vs_stat_rect_cuts_electrons.py
@@ -1,0 +1,55 @@
+import ROOT
+
+from ROOT import TGraphErrors
+from array import array
+
+from mva_tools.build_roc_simple import build_roc 
+
+
+if __name__ == "__main__":
+
+    path = "/Users/musthero/Documents/Yura/Applications/tmva_local/BDT_score_distributions_electrons.root"
+    hsig_path = "histo_tmva_sig"
+    hbkg_path = "histo_tmva_bkg"
+
+    rootfile = ROOT.TFile.Open(path)
+
+    if rootfile.IsZombie():
+        print "Root file is corrupt"
+
+    hSig = rootfile.Get(hsig_path)
+    hBkg = rootfile.Get(hbkg_path)
+
+    g = build_roc(hSig, hBkg, 1)
+    ll = [g]
+
+    g.SetLineColor(ROOT.kBlue)
+    g.Draw("AL") # draw TGraph with no marker dots
+
+
+    # Draw rectangular cuts
+
+
+    eff_rej = (0.889199,0.898912,0.000337,0.001671)
+    sig_eff_val = array('f', [eff_rej[0]])
+    sig_eff_err = array('f', [eff_rej[1]])
+    bkg_rej_val = array('f', [eff_rej[2]])
+    bkg_rej_err = array('f', [eff_rej[3]])
+
+
+    n = 1
+    #gr = TGraphErrors(n, sig_eff_val, sig_eff_err, bkg_rej_val, bkg_rej_err)
+    #gr = TGraphErrors(n, sig_eff_val, sig_eff_err, bkg_rej_val, bkg_rej_err)
+    gr = TGraphErrors(n, sig_eff_val, sig_eff_err, bkg_rej_val, bkg_rej_err)
+    print sig_eff_val, sig_eff_err, bkg_rej_val, bkg_rej_err
+    #gr.Draw("AC*")
+    gr.SetMarkerColor(2)
+    gr.SetLineColor(2)
+    gr.SetLineWidth(2)
+     
+    gr.Draw("psame")
+
+
+
+
+

--- a/test/stat_rect_cuts_electrons_fast.py
+++ b/test/stat_rect_cuts_electrons_fast.py
@@ -1,0 +1,95 @@
+import ROOT
+import sys
+
+from math import *
+from array import *
+
+#filelist = [ "/Users/musthero/Documents/Yura/Applications/tmva_local/output_muons_0.root" ] 
+#filelist = [ "/Users/musthero/Documents/Yura/Applications/tmva_local/output_muons_test.root" ] 
+filelist = [ "/Users/musthero/Documents/Yura/Applications/TMVA-v4.2.0/test/output_electrons_fullsim_v5_20per.root" ]
+
+
+profile = ROOT.TProfile("RECTCuts", "RECTCuts", 100, 0, 1, "s");
+
+for filename in filelist:
+
+    # Get TTree
+    file = ROOT.TFile.Open(filename)
+    tree = file.JINRTree_3
+
+    # Declare counting variables
+    prompt_all = 0; prompt_pass = 0;
+    nonprompt_all = 0; nonprompt_pass = 0; nonprompt_rej = 0;
+    
+    # Declare variables of interest
+    m_el_ptcone20Dpt = array('f',[0])
+    m_el_etcone20Dpt = array('f',[0])
+    m_el_isprompt = array('i', [0])
+    m_el_VeryTightLH = array('i',[0])
+    m_el_screwed_isprompt = array('i',[0])
+    m_el_EleIso = array('i',[0])
+    m_el_Z0SinTheta = array('i',[0])
+    m_el_Sigd0PV = array('i',[0])
+
+    # Link variables of interest to the tree
+    tree.SetBranchAddress( "m_el_ptcone20Dpt", m_el_ptcone20Dpt )
+    tree.SetBranchAddress( "m_el_etcone20Dpt", m_el_etcone20Dpt )
+    tree.SetBranchAddress( "m_el_VeryTightLH", m_el_VeryTightLH )
+    tree.SetBranchAddress( "m_el_isprompt", m_el_isprompt )
+    tree.SetBranchAddress( "m_el_screwed_isprompt", m_el_screwed_isprompt )
+    tree.SetBranchAddress( "m_el_EleIso", m_el_EleIso )
+    tree.SetBranchAddress( "m_el_Z0SinTheta", m_el_Z0SinTheta )
+    tree.SetBranchAddress( "m_el_Sigd0PV", m_el_Sigd0PV )
+
+    c = 0
+    #for e in file.JINRTree:
+    while tree.GetEntry(c):
+        c = c + 1
+
+        if (c % 100000 == 0):
+            print "Event number %i" % c
+            sys.stdout.flush()
+
+        # Preselection cuts
+        #if m_el_isprompt[0] == 1 and m_el_Tight[0] == 1 and m_el_screwed_isprompt[0] == 0:    # Signal (take from TCut in TMVAMuon.C for signal):
+        if m_el_isprompt[0] == 1 and m_el_VeryTightLH[0] == 1:    # Signal (take from TCut in TMVAMuon.C for signal):
+            prompt_all += 1
+        #elif m_el_isprompt[0] == 0 and m_el_Tight[0] == 1 and m_el_screwed_isprompt[0] == 0:  # Background (take from TCut in TMVAMuon.C for background):
+        elif m_el_isprompt[0] == 0 and m_el_VeryTightLH[0] == 1:  # Background (take from TCut in TMVAMuon.C for background):
+            nonprompt_all += 1
+        else:
+            continue
+
+        # Standard selection cuts
+        if m_el_VeryTightLH[0] == 1 and m_el_EleIso[0] == 1 and m_el_Z0SinTheta[0] == 1 and m_el_Sigd0PV[0] == 1:
+            if m_el_isprompt[0] == 1:
+                prompt_pass += 1
+            elif m_el_isprompt[0] == 0:
+                nonprompt_pass += 1
+            else:
+                print "Unable to figure out lepton type (prompt/non-prompt)"
+                ROOT.gApplication.Terminate()
+
+    nonprompt_rej = nonprompt_all - nonprompt_pass
+    sig_eff_val = float(prompt_pass)/prompt_all
+    sig_eff_err = (1/float(prompt_all))*sqrt(prompt_pass*(1-float(prompt_pass)/prompt_all))
+    bkg_rej_val = float(nonprompt_rej)/nonprompt_all
+    bkg_rej_err = (1/float(nonprompt_all))*sqrt(nonprompt_rej*(1-float(nonprompt_rej)/nonprompt_all))
+
+    print filename,":"
+    print "    Sig eff:", sig_eff_val
+    print "    Sig eff error:", sig_eff_err
+    print "    Bkg rej:", bkg_rej_val
+    print "    Bkg rej error:", bkg_rej_err
+    print "    Prompt all,pass:", prompt_all,prompt_pass
+    print "    Non-prompt all,rej:", nonprompt_all,nonprompt_rej
+
+    print "(%f,%f,%f,%f)" % (sig_eff_val, bkg_rej_val, sig_eff_err, bkg_rej_err)
+    
+    profile.Fill(sig_eff_val, bkg_rej_val, 1)
+    file.Close()
+
+profile.SetLineColor(2)
+profile.SetLineWidth(6)
+profile.Draw()
+


### PR DESCRIPTION
New scripts for electrons,
1. apply_bdt_tmva_electrons.py - a script that computes BDT score
distribution
2. draw_roc_vs_stat_rect_cuts_electrons.py - a script that compares
ROC-curve with the standard cuts
