### PR TITLE
Tree values scaled by learning rate

### DIFF
--- a/examples/bdt_sklearn_to_tmva_Grad.py
+++ b/examples/bdt_sklearn_to_tmva_Grad.py
@@ -30,7 +30,7 @@ X_train, y_train, w_train = X, y, w
 
 # Declare BDT - we are going to use AdaBoost Decision Tree
 bdt = GradientBoostingClassifier(
-    n_estimators=200, learning_rate=0.5,
+    n_estimators=100, learning_rate=0.01,
     min_samples_leaf=int(0.05*len(X_train)),
     max_depth=3, random_state=0)
 

--- a/examples/validate_sklearn_to_tmva.py
+++ b/examples/validate_sklearn_to_tmva.py
@@ -97,6 +97,9 @@ n = X.shape[0]
 # Iterate over events
 # Note: this is not the fastest way for sklearn
 #        but most representative, I believe
+import matplotlib.pyplot as plt
+bdts=[]
+skls=[]
 for i in xrange(n):
 
     if (i % 100 == 0) and (i != 0):
@@ -106,16 +109,19 @@ for i in xrange(n):
     var2[0] = X.item((i,1))
 
     # sklearn score
-    score = bdt.decision_function([var1[0], var2[0]]).item(0)
+    score = bdt.predict_proba([var1[0], var2[0]])[0][1]
 
     # calculate the value of the classifier with TMVA/TskMVA
-    bdtOutput = reader.EvaluateMVA("BDT")
+    bdtOutput = (reader.EvaluateMVA("BDT")+1)/2.
+    bdts.append(bdtOutput)
+    skls.append(score)
 
     # save skleanr and TMVA BDT output scores
     sk_y_predicted.append(score)
     tmva_y_predicted.append(bdtOutput)
 
-
+plt.scatter(bdts,skls)
+plt.show()
 # Convert arrays to numpy arrays
 sk_y_predicted = np.array(sk_y_predicted)
 tmva_y_predicted = np.array(tmva_y_predicted)


### PR DESCRIPTION
Pryvit, kozache! :)
Thanks for the wonderful scripts! The conversion works great, however I noticed that EvaluateMVA returns different values from sklearn. The result of skTMVA trees should be scaled by the learning rate (shrinkage). I've added a scatter plot to compare outputs of skTMVA and sklearn ( examples/validate_sklearn_to_tmva.py line 123)
Here is how it looks by default
<img width="599" alt="image" src="https://cloud.githubusercontent.com/assets/2255101/21963854/1b5d0498-db4a-11e6-85a1-b9b188fda60c.png">

here is how it looks when tree value is multiplied by `learning_rate/2.` in skTMVA.py
<img width="576" alt="image" src="https://cloud.githubusercontent.com/assets/2255101/21963879/716f14a2-db4a-11e6-8ae0-2d86a35707d0.png">

The "2" factor comes from different definitions of exponential transformation in the end:
https://root.cern.ch/root/html/src/TMVA__MethodBDT.cxx.html#1349
and
https://github.com/scikit-learn/scikit-learn/blob/14031f6/sklearn/ensemble/gradient_boosting.py#L521

I hope you find this useful!
Question: do you plan writing such a script for XGBoost? 

Thanks!
Stas
